### PR TITLE
Remove redundant `max_pin`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 1
   skip: true  # [not linux]
   run_exports:
-    - {{ pin_subpackage("rdma-core", max_pin="x") }}
+    - {{ pin_subpackage("rdma-core") }}
 
 requirements:
   build:


### PR DESCRIPTION
The currently set `max_pin` matches the default, see https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#extra-jinja2-functions, thus making it redundant.

Because this will result in no change to the package, we will hold on before moving this and wait for the next package change instead.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
