### PR TITLE
Fix rdma-core sysusers install path

### DIFF
--- a/recipe/0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
+++ b/recipe/0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
@@ -131,6 +131,7 @@ index 000000000..e8d25a552
 +
 +#include <stdlib.h>
 +#include <stdio.h>
++#include <string.h>
 +#include <sys/un.h>
 +#include <util/conda_forge.h>
 +
@@ -162,8 +163,7 @@ index 000000000..e8d25a552
 +
 +void validate_and_copy_path(char* dst, const char* src) {
 +	validate_path_length(src);
-+	strncpy(dst, src, sizeof(dst) - 1);
-+	dst[sizeof(dst) - 1] = '\0';
++	strcpy(dst, src);
 +}
 +
 +#pragma GCC pop_options
@@ -186,4 +186,3 @@ index 000000000..7cefc004c
 +#endif
 -- 
 2.40.1
-

--- a/recipe/0002-Allow-overriding-sysusers-install-directory.patch
+++ b/recipe/0002-Allow-overriding-sysusers-install-directory.patch
@@ -1,0 +1,37 @@
+From c7cd7ba58bdcd336de3caf99e14fa8c225c76808 Mon Sep 17 00:00:00 2001
+From: Peter Andreas Entschev <peter@entschev.com>
+Date: Fri, 8 May 2026 02:34:00 -0700
+Subject: [PATCH] Allow overriding sysusers install directory
+
+The systemd pkg-config file reports an absolute sysusers.d directory
+outside conda's install prefix. Make the directory configurable so the
+feedstock can keep installed files inside the package prefix.
+---
+ CMakeLists.txt | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6c923b68a..5f4671b89 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -600,11 +600,13 @@ RDMA_DoFixup("${SYSTEMD_FOUND}" "systemd/sd-daemon.h")
+ 
+ # https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html
+-set(SYSUSERS_DIR "")
+-if (NOT ${CMAKE_VERSION} VERSION_LESS "3.4")
+-  pkg_check_modules(SYSTEMD_PC systemd QUIET)
+-  if (SYSTEMD_PC_FOUND)
+-    pkg_get_variable(SYSUSERS_DIR systemd sysusersdir)
++set(SYSUSERS_DIR "" CACHE PATH "Location for systemd sysusers.d files")
++if ("${SYSUSERS_DIR}" STREQUAL "")
++  if (NOT ${CMAKE_VERSION} VERSION_LESS "3.4")
++    pkg_check_modules(SYSTEMD_PC systemd QUIET)
++    if (SYSTEMD_PC_FOUND)
++      pkg_get_variable(SYSUSERS_DIR systemd sysusersdir)
++    endif()
+   endif()
+ endif()
+ if ("${SYSUSERS_DIR}" STREQUAL "")
+   set(SYSUSERS_DIR "/usr/lib/sysusers.d")
+-- 
+2.40.1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,8 @@ cmake ${CMAKE_ARGS} \
       -D CMAKE_BUILD_TYPE:STRING="${CMAKE_CONFIG}" \
       -D CMAKE_PREFIX_PATH:PATH="${PREFIX}" \
       -D CMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+      -D CMAKE_INSTALL_SYSTEMD_BINDIR:PATH="${PREFIX}/lib/systemd" \
+      -D SYSUSERS_DIR:PATH="${PREFIX}/lib/sysusers.d" \
       "${SRC_DIR}" \
 ;
 cmake --build . --parallel ${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 3a1808f419bad566b33d844b532dd9c899500c7e008615f7a1c0d0ca26b4f1be
   patches:
     - 0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
+    - 0002-Allow-overriding-sysusers-install-directory.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage("rdma-core", max_pin=None) }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add an upstream-style patch that makes the systemd sysusers.d install directory configurable, register it in the recipe, and pass `SYSUSERS_DIR` plus `CMAKE_INSTALL_SYSTEMD_BINDIR` under `PREFIX` so conda-build does not try to install files into `/usr/lib`. The fix is being proposed upstream in https://github.com/linux-rdma/rdma-core/pull/1737.

Also fix the existing conda path helper to copy the already-validated socket path with `strcpy` instead of using sizeof on a pointer, which truncated the copied path.